### PR TITLE
fix calculator output, format to 2 decimal places

### DIFF
--- a/day-2-tip-calculator-start/main.py
+++ b/day-2-tip-calculator-start/main.py
@@ -27,6 +27,6 @@ total_tip = bill * percent_tip
 total_bill = total_tip + bill
 
 # Split between number of people
-bill_per_person = round(total_bill / num_people, 2)
+bill_per_person = "{:.2f}".format((total_bill / num_people))
 
 print(f"Each person should pay: ${bill_per_person}")


### PR DESCRIPTION
using the format function instead of round, force the output to always display 2 decimal places even if the result only contains 1

for example

```
Welcome to the tip calculator!
What was the total bill? $150
How much tip would you like to give? e.g. 10, 12, or 15? 12
How many people to split the bill? 5
Each person should pay: $33.6
```

vs

```
Welcome to the tip calculator!
What was the total bill? $150
How much tip would you like to give? e.g. 10, 12, or 15? 12
How many people to split the bill? 5
Each person should pay: $33.60
```